### PR TITLE
Document cache_salt and extra_key usage

### DIFF
--- a/docs/basic_usage/openai_api_completions.ipynb
+++ b/docs/basic_usage/openai_api_completions.ipynb
@@ -233,7 +233,23 @@
     "\n",
     "The chat completions API accepts OpenAI Chat Completions API's parameters. Refer to [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create) for more details.\n",
     "\n",
-    "SGLang extends the standard API with the `extra_body` parameter, allowing for additional customization. One key option within `extra_body` is `chat_template_kwargs`, which can be used to pass arguments to the chat template processor."
+    "SGLang extends the standard API with the `extra_body` parameter, allowing for additional customization. One key option within `extra_body` is `chat_template_kwargs`, which can be used to pass arguments to the chat template processor.\n",
+    "\n",
+    "In addition to template options, you can control prefix caching by supplying request-level keys via `extra_body`. The `cache_salt` field lets you isolate cache entries between tenants or prompt versions, while `extra_key` allows attaching arbitrary identifiers (for example, a LoRA adapter name). The server concatenates the two values (when both are provided) and uses the result alongside the prompt tokens to look up cached prefixes, so only requests with matching tokens and key information will share cache hits.\n",
+    "\n",
+    "```python\n",
+    "response = client.chat.completions.create(\n",
+    "    model=model,\n",
+    "    messages=messages,\n",
+    "    extra_body={\n",
+    "        \"cache_salt\": \"tenant-a\",\n",
+    "        \"extra_key\": \"lora-news-bot\",\n",
+    "    },\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "Reusing the same key values keeps prefix caches warm; changing either value forces the server to build a fresh cache for that request group.\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- document how to pass cache_salt and extra_key through extra_body in the OpenAI chat completions docs
- clarify that the two fields are combined with the prompt tokens to control prefix cache reuse and include an example snippet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0a04931808323bd2437b75f397aba