### PR TITLE
Enhance kimi-k2 parser unit tests

### DIFF
--- a/sgl-router/src/tool_parser/parsers/kimik2_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/kimik2_parser.rs
@@ -97,11 +97,11 @@ impl ToolParser for KimiK2Parser {
                 let function_args = args_match.as_str();
 
                 // Parse function ID
-                if let Some((func_name, _index)) = self.parse_function_id(function_id) {
+                if let Some((func_name, index)) = self.parse_function_id(function_id) {
                     // Validate JSON arguments
                     if serde_json::from_str::<serde_json::Value>(function_args).is_ok() {
-                        // Generate unique ID
-                        let id = format!("kimi_call_{}", uuid::Uuid::new_v4());
+                        // Use deterministic ID aligned with OpenAI-style tool_call_id
+                        let id = format!("call_{}", index);
 
                         tools.push(ToolCall {
                             id,
@@ -146,12 +146,12 @@ impl ToolParser for KimiK2Parser {
                 let partial_args = args_match.as_str();
 
                 // Parse function ID
-                if let Some((func_name, _index)) = self.parse_function_id(function_id) {
+                if let Some((func_name, index)) = self.parse_function_id(function_id) {
                     // Send function name if not sent yet
                     if !state.in_string {
                         state.in_string = true; // Mark name as sent
                         return Ok(StreamResult::ToolName {
-                            index: 0,
+                            index,
                             name: func_name.clone(),
                         });
                     }
@@ -163,8 +163,8 @@ impl ToolParser for KimiK2Parser {
 
                         // Validate and parse JSON
                         if serde_json::from_str::<serde_json::Value>(json_args).is_ok() {
-                            // Generate unique ID
-                            let id = format!("kimi_call_{}", uuid::Uuid::new_v4());
+                            // Use deterministic ID aligned with OpenAI-style tool_call_id
+                            let id = format!("call_{}", index);
 
                             let tool = ToolCall {
                                 id,
@@ -194,7 +194,7 @@ impl ToolParser for KimiK2Parser {
                                     .unwrap_or_else(|_| "{}".to_string());
 
                                 return Ok(StreamResult::ToolArguments {
-                                    index: 0,
+                                    index,
                                     arguments: args_str,
                                 });
                             }


### PR DESCRIPTION
## Motivation

This pull request enhances the unit tests for the Kimi-K2 function calling parser to ensure robust handling of multi-turn tool calls and correct, deterministic ordering of `call_id`s, aligning with Kimi's official tool call guidance.

## Modifications

- Updated the KimiK2 parser to generate deterministic `tool_call_id`s (e.g., `call_0`, `call_1`) based on the parsed index, replacing UUID-based IDs.
- Ensured the correct `index` is propagated in streaming results for `ToolName` and `ToolArguments` events.
- Added new unit tests to cover:
    - Verification of deterministic `call_id` ordering in complete parsing.
    - Correct `index` propagation and `call_id` generation during streaming.
    - Proper resetting of `call_id` indices (`call_0` for the first tool) across multi-turn `tool_calls_section`s.

## Accuracy Tests

Not applicable, as this PR focuses on parser logic and unit tests, not model outputs.

## Benchmarking and Profiling

Not applicable, as this PR focuses on parser logic and unit tests, with minimal performance impact expected.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

---
<a href="https://cursor.com/background-agent?bcId=bc-55f15c24-6087-4ebb-ae88-e86f2be4c2e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55f15c24-6087-4ebb-ae88-e86f2be4c2e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generate deterministic `tool_call_id` (`call_{index}`) and propagate parsed `index` in streaming outputs; add tests for ordering, streaming, and multi-turn resets.
> 
> - **Parser (KimiK2)**:
>   - Use parsed `index` to set deterministic `id` as `call_{index}` instead of UUID for both complete and streaming parsing.
>   - Propagate parsed `index` in `StreamResult::ToolName` and `StreamResult::ToolArguments` (replacing hardcoded `0`).
> - **Tests**:
>   - Add assertions for deterministic `id`s (`call_0`, `call_1`, etc.) in complete parsing.
>   - New streaming tests validating correct `index` propagation and ordered deterministic `id`s across multiple tools.
>   - Add multi-turn tests ensuring indices reset per `tool_calls_section`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d48039af58e890d2e5b4a5e3e7d407ac96d12e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->