### PR TITLE
[Docs] MiMo-V2.5 cookbook: fill B200 §5.1.1/5.2 benchmarks + add long-context §5.4 reference

### DIFF
--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -348,9 +348,11 @@ python3 -m sglang.test.run_eval \
 > `run_eval.py` automatically appends `/v1` to `--base-url`; pass the bare `host:port` URL (without trailing `/v1`), otherwise requests resolve to `/v1/v1/chat/completions` and 404.
 
 - **Test Results:**
-  - MiMo-V2.5-Pro (FP8)
+  - MiMo-V2.5-Pro (FP8, 8× B200)
     ```
-    Pending update
+    Score:             0.965  (193 / 200)
+    Latency:           253.90 s
+    Output throughput: 461.78 tok/s
     ```
   - MiMo-V2.5 (FP8, 8× H200)
     ```
@@ -384,9 +386,11 @@ python3 benchmark/mmmu/bench_sglang.py \
 
 - Hardware: NVIDIA B200 GPU (8×)
 - Model: `XiaomiMiMo/MiMo-V2.5-Pro` (FP8)
-- Tensor Parallelism: 8
-- Recipe: Balanced (DP-attn + DeepEP + EAGLE MTP)
-- sglang version: Pending update
+- Tensor Parallelism: 8 (single-node, `--moe-runner-backend flashinfer_trtllm`, `--attention-backend fa4`, `--mem-fraction-static 0.8`, `--swa-full-tokens-ratio 0.1`)
+- Recipe: Blackwell verified baseline (no EAGLE — see note below)
+- sglang version: 0.5.11
+
+> EAGLE MTP speculative decoding is the recommended decode-side optimization for B200 (typically a 2–3× decode speedup) but at sglang 0.5.11 the draft-model init hangs on this checkpoint. The numbers below are the **no-EAGLE baseline**; EAGLE-enabled numbers will be appended once the init regression is resolved.
 
 #### 5.2.1 Latency-Sensitive Benchmark
 
@@ -408,7 +412,43 @@ python3 -m sglang.bench_serving \
 - **Test Results:**
 
 ```text Output
-Pending update — replace with real bench_serving output after the latency run.
+============ Serving Benchmark Result ============
+Backend:                                 sglang
+Traffic request rate:                    inf
+Max request concurrency:                 1
+Successful requests:                     10
+Benchmark duration (s):                  27.59
+Total input tokens:                      1997
+Total input text tokens:                 1997
+Total generated tokens:                  2798
+Total generated tokens (retokenized):    2794
+Request throughput (req/s):              0.36
+Input token throughput (tok/s):          72.38
+Output token throughput (tok/s):         101.41
+Peak output token throughput (tok/s):    110.00
+Peak concurrent requests:                3
+Total token throughput (tok/s):          173.79
+Concurrency:                             1.00
+----------------End-to-End Latency----------------
+Mean E2E Latency (ms):                   2757.26
+Median E2E Latency (ms):                 3319.10
+P90 E2E Latency (ms):                    4157.47
+P99 E2E Latency (ms):                    4869.32
+---------------Time to First Token----------------
+Mean TTFT (ms):                          162.17
+Median TTFT (ms):                        68.11
+P99 TTFT (ms):                           929.58
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          9.19
+Median TPOT (ms):                        9.33
+P99 TPOT (ms):                           9.39
+---------------Inter-Token Latency----------------
+Mean ITL (ms):                           9.31
+Median ITL (ms):                         9.35
+P95 ITL (ms):                            9.44
+P99 ITL (ms):                            9.77
+Max ITL (ms):                            19.80
+==================================================
 ```
 
 #### 5.2.2 Throughput-Sensitive Benchmark
@@ -431,7 +471,43 @@ python3 -m sglang.bench_serving \
 - **Test Results:**
 
 ```text Output
-Pending update — replace with real bench_serving output after the throughput run.
+============ Serving Benchmark Result ============
+Backend:                                 sglang
+Traffic request rate:                    inf
+Max request concurrency:                 100
+Successful requests:                     1000
+Benchmark duration (s):                  112.78
+Total input tokens:                      302118
+Total input text tokens:                 302118
+Total generated tokens:                  195775
+Total generated tokens (retokenized):    191069
+Request throughput (req/s):              8.87
+Input token throughput (tok/s):          2678.83
+Output token throughput (tok/s):         1735.90
+Peak output token throughput (tok/s):    3040.00
+Peak concurrent requests:                121
+Total token throughput (tok/s):          4414.73
+Concurrency:                             87.80
+----------------End-to-End Latency----------------
+Mean E2E Latency (ms):                   9901.96
+Median E2E Latency (ms):                 6525.54
+P90 E2E Latency (ms):                    23567.98
+P99 E2E Latency (ms):                    42109.22
+---------------Time to First Token----------------
+Mean TTFT (ms):                          223.69
+Median TTFT (ms):                        139.45
+P99 TTFT (ms):                           1082.02
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          50.63
+Median TPOT (ms):                        51.66
+P99 TPOT (ms):                           91.41
+---------------Inter-Token Latency----------------
+Mean ITL (ms):                           49.79
+Median ITL (ms):                         33.69
+P95 ITL (ms):                            103.37
+P99 ITL (ms):                            151.34
+Max ITL (ms):                            1600.00
+==================================================
 ```
 
 ### 5.3 Speed Benchmark — MiMo-V2.5
@@ -624,3 +700,76 @@ P99 ITL (ms):                            11.12
 Max ITL (ms):                            37.67
 ==================================================
 ```
+
+### 5.4 Long-Context Prefill & MTP Decode — MiMo-V2.5-Pro (Reference)
+
+Reference numbers from the [day0 enablement PR](https://github.com/sgl-project/sglang/pull/23808), collected on a 2-node Hopper deployment with the **EP=16, DP=2, TP=16** recipe (`--moe-a2a-backend deepep`, `--attention-backend fa3`, `--enable-multi-layer-eagle`). The setup, parallelism, and benchmark methodology all differ from §5.2 (Blackwell TP=8 with `random 1024/1024`), so treat these as a separate operating point — long-context prefill scaling and the MTP decode speedup — rather than a comparison against §5.2.
+
+**Test Environment:**
+
+- Hardware: NVIDIA Hopper GPU (2 nodes × 8 GPUs, GPU SKU intentionally not disclosed)
+- Model: `XiaomiMiMo/MiMo-V2.5-Pro` (FP8)
+- Parallelism: `--tp 16 --dp 2 --ep 16 --moe-dense-tp-size 1 --enable-dp-attention`
+- Recipe: Hopper EP16 (DeepEP + EAGLE multi-layer MTP)
+
+#### 5.4.1 Long-Context Prefill Throughput
+
+Test setting: `chunked_prefill_size=32K`, `random_output_len=1`, cache flushed before every run. For input lengths ≥ 512K the workload was split into two requests routed to distinct DP ranks and the per-node throughput was read from `bench_serving` output.
+
+- **Benchmark Command:**
+
+```shell Command
+python3 -m sglang.bench_serving \
+  --backend sglang \
+  --model XiaomiMiMo/MiMo-V2.5-Pro \
+  --host 0.0.0.0 \
+  --port 30000 \
+  --dataset-name random \
+  --random-input-len <INPUT_LEN> \
+  --random-output-len 1 \
+  --random-range-ratio 1.0 \
+  --flush-cache \
+  --seed 12345 \
+  --num-prompts 10000
+```
+
+- **Test Results** — single-node prefill throughput, cache-miss:
+
+| Input length | Output length | Single-node prefill throughput |
+| ------------ | ------------- | ------------------------------ |
+| 4K           | 1             | 30.80K tok/s                   |
+| 8K           | 1             | 30.65K tok/s                   |
+| 16K          | 1             | 29.85K tok/s                   |
+| 32K          | 1             | 28.60K tok/s                   |
+| 64K          | 1             | 26.65K tok/s                   |
+| 128K         | 1             | 23.00K tok/s                   |
+| 256K         | 1             | 17.90K tok/s                   |
+| 512K         | 1             | 11.30K tok/s                   |
+| 768K         | 1             | 9.40K tok/s                    |
+| 1M           | 1             | 7.30K tok/s                    |
+
+Prefill throughput stays within ~10% of peak from 4K up to 32K and degrades gracefully past 128K, confirming the hybrid SWA+GA attention works correctly at 1M context.
+
+#### 5.4.2 Decode Throughput — MTP Speedup
+
+Test setting: fixed **16K input / 1K output**, varying batch size per DP rank, with and without the 3-layer MTP module. `MTP accept length` is the average number of draft tokens accepted per step under EAGLE speculative decoding.
+
+- **Test Results** — single-node decode throughput:
+
+| BS per DP rank | MTP      | MTP accept length | TPS  | Single-node decode throughput |
+| -------------- | -------- | ----------------- | ---- | ----------------------------- |
+| 64             | disabled | -                 | 29.3 | 1875 tok/s                    |
+| 64             | 3-layer  | 3                 | 60.5 | 3873 tok/s                    |
+| 64             | 3-layer  | 4                 | 79.7 | 5103 tok/s                    |
+| 96             | disabled | -                 | 26.7 | 2564 tok/s                    |
+| 96             | 3-layer  | 3                 | 50.4 | 4840 tok/s                    |
+| 96             | 3-layer  | 4                 | 64.8 | 6225 tok/s                    |
+
+**Summary — MTP on / off:**
+
+| BS per DP rank | Without MTP | 3-layer MTP, accept=3 | 3-layer MTP, accept=4 |
+| -------------- | ----------- | --------------------- | --------------------- |
+| 64             | 1875 tok/s  | 3873 tok/s (2.07×)    | 5103 tok/s (2.72×)    |
+| 96             | 2564 tok/s  | 4840 tok/s (1.89×)    | 6225 tok/s (2.43×)    |
+
+The 3-layer MTP module delivers ~2× decode throughput at accept length 3 and ~2.5–2.7× at accept length 4 — the same order of magnitude as the "2–3× decode speedup" guidance in §3.2.


### PR DESCRIPTION
## Summary

Fills the four `Pending update` blocks in the `MiMo-V2.5` cookbook (`docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx`) and adds one new reference section.

- **§5.1.1 GSM8K — MiMo-V2.5-Pro**: 0.965 (193/200), 253.90 s, 461.78 tok/s
- **§5.2.1 Latency-sensitive (1024/1024, concurrency=1, 10 prompts)**: 101.41 tok/s output, 9.19 ms mean TPOT, 162.17 ms mean TTFT
- **§5.2.2 Throughput-sensitive (1024/1024, concurrency=100, 1000 prompts)**: 1735.90 tok/s output, 4414.73 tok/s total, 50.63 ms mean TPOT
- **§5.4 (new) Long-context prefill (4K→1M) and MTP decode speedup**: pulled in as reference from the day0 enablement PR #23808 (Hopper EP=16 / 2-node, GPU SKU intentionally hidden in source). Annotated as a separate operating point from §5.2 so the numbers don't get cross-compared.

Also updates **§5.2 Test Environment** with the exact verified launch flags (`--moe-runner-backend flashinfer_trtllm --attention-backend fa4 --mem-fraction-static 0.8 --swa-full-tokens-ratio 0.1`) and pins `sglang version: 0.5.11`.

## Caveat: EAGLE MTP

§5.2 numbers were collected **without** EAGLE speculative decoding. At sglang 0.5.11 the EAGLE draft-model init hangs on the MiMo-V2.5-Pro checkpoint (target loads fine, then the draft \`Load weight begin\` produces no further log output, GPU util goes to 0%, and the server never reaches ready). The cookbook §5.2 environment block now calls this out and promises an EAGLE-enabled update once the regression is fixed.

The expected 2–3× decode speedup from EAGLE MTP is already documented in §3.2 and corroborated by §5.4 (Xiaomi's own Hopper-side MTP-on/off table).

## Local patch used for benchmarking

\`MiMoV2ForCausalLM\` is currently registered as a multimodal arch (\`MIMO_V2_MULTIMODAL_ARCHS = (\"MiMoV2ForCausalLM\",)\` in \`python/sglang/srt/configs/model_config.py:46\`), but the V2.5-**Pro** checkpoint is text-only and has no \`vision_config\`, so \`MiMoV2Processor.__init__\` crashes during tokenizer-manager init. Locally bypassed by setting \`MIMO_V2_MULTIMODAL_ARCHS = ()\`. Not part of this PR — needs a real fix in sglang main (probably a runtime \`hasattr(hf_config, \"vision_config\")\` guard).

## Test plan

- [x] All 3 benchmarks run cleanly on 8× B200 (sglang 0.5.11) — output captured verbatim into the cookbook
- [ ] Render the \`docs_new\` site locally and verify §5 layout (tables, code blocks, anchor links) doesn't break
- [ ] Reviewer: confirm whether the PR #23808 numbers (currently §5.4) should stay under §5 or move into a sibling section / appendix

🤖 Generated with [Claude Code](https://claude.com/claude-code)