### PR TITLE
feat(minimax-m3): piecewise CUDA graph for sparse prefill (default-on)

### DIFF
--- a/python/sglang/jit_kernel/minimax_qknorm_rope.py
+++ b/python/sglang/jit_kernel/minimax_qknorm_rope.py
@@ -28,6 +28,7 @@ from sglang.jit_kernel.utils import (
     load_jit,
     make_cpp_args,
 )
+from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -43,6 +44,52 @@ def _jit_module(pos_dtype, head_dim, rope_dim) -> Module:
         *args,
         cuda_files=["minimax/fused_gemma_qknorm_rope.cuh"],
         cuda_wrappers=[("fused_gemma_qknorm_rope", f"fused_gemma_qknorm_rope<{args}>")],
+    )
+
+
+@register_custom_op(mutates_args=["qkv"])
+def _fused_gemma_qknorm_rope(
+    qkv: torch.Tensor,
+    w0: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w3: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    off0: int,
+    cnt0: int,
+    off1: int,
+    cnt1: int,
+    off2: int,
+    cnt2: int,
+    off3: int,
+    cnt3: int,
+    num_groups: int,
+    eps: float,
+) -> None:
+    # Wrap the tvm-ffi kernel as a custom op so torch.compile / piecewise CUDA
+    # graph can trace past the otherwise-opaque FFI call. The launch is
+    # graph-capturable (host-side constant offsets/counts), so it stays inside
+    # the captured region.
+    module = _jit_module(positions.dtype, 128, 64)
+    module.fused_gemma_qknorm_rope(
+        qkv,
+        w0,
+        w1,
+        w2,
+        w3,
+        cos_sin_cache,
+        positions,
+        off0,
+        cnt0,
+        off1,
+        cnt1,
+        off2,
+        cnt2,
+        off3,
+        cnt3,
+        num_groups,
+        eps,
     )
 
 
@@ -80,8 +127,7 @@ def minimax_qknorm_rope_grouped(
         offsets.append(0)
         counts.append(0)
 
-    module = _jit_module(positions.dtype, 128, 64)
-    module.fused_gemma_qknorm_rope(
+    _fused_gemma_qknorm_rope(
         qkv,
         weights[0],
         weights[1],

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -381,8 +381,15 @@ class ModelConfig:
             self.hf_config.architectures
         )
         self.use_ngram_embedding = getattr(self.hf_config, "use_ngram_embedding", False)
+        # A multimodal arch is piecewise-incompatible until its LM prefill is validated.
         self.is_piecewise_cuda_graph_disabled_model = (
             is_piecewise_cuda_graph_disabled_model(self.hf_config.architectures)
+            or (
+                self.is_multimodal
+                and not is_multimodal_piecewise_cuda_graph_supported(
+                    self.hf_config.architectures
+                )
+            )
         )
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
 
@@ -1719,6 +1726,21 @@ def is_multimodal_chunked_prefill_supported(model_architectures: List[str]):
 def is_piecewise_cuda_graph_disabled_model(model_architectures: List[str]):
     return any(
         arch in piecewise_cuda_graph_disabled_model_archs
+        for arch in model_architectures
+    )
+
+
+# Multimodal archs whose LM-decoder prefill is validated under piecewise CUDA
+# graph (capture wraps only the decoder; the image encoder runs eager).
+multimodal_piecewise_cuda_graph_supported_archs = [
+    "MiniMaxM3SparseForCausalLM",
+    "MiniMaxM3SparseForConditionalGeneration",
+]
+
+
+def is_multimodal_piecewise_cuda_graph_supported(model_architectures: List[str]):
+    return any(
+        arch in multimodal_piecewise_cuda_graph_supported_archs
         for arch in model_architectures
     )
 

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -128,6 +128,34 @@ class RadixAttention(nn.Module):
             forward_batch.forward_mode.is_extend()
             and get_tc_piecewise_forward_context() is not None
         ):
+            # MiniMax-M3 sparse attention returns (idx_output, attn_output) and
+            # takes idx_q/idx_k/idx_v — it needs the dual-output split op below.
+            # The breakable backend has no sparse variant yet, so run eagerly there.
+            if kwargs.get("idx_q") is not None:
+                if is_in_breakable_cuda_graph():
+                    return get_attn_backend().forward(
+                        q, k, v, self, forward_batch, save_kv_cache, **kwargs
+                    )
+                idx_q = kwargs["idx_q"]
+                idx_k = kwargs["idx_k"]
+                idx_v = kwargs.get("idx_v")
+                attn_out = q.new_empty(
+                    (q.shape[0], self.tp_q_head_num * self.v_head_dim)
+                )
+                idx_out = q.new_empty((q.shape[0], idx_q.shape[1] * idx_q.shape[2]))
+                unified_sparse_attention_with_output(
+                    q,
+                    k,
+                    v,
+                    attn_out,
+                    idx_out,
+                    idx_q,
+                    idx_k,
+                    save_kv_cache,
+                    self.layer_id,
+                    idx_v=idx_v,
+                )
+                return idx_out, attn_out
             if self.qk_head_dim != self.v_head_dim:
                 output = q.new_empty((q.shape[0], self.tp_q_head_num * self.v_head_dim))
             else:
@@ -249,6 +277,79 @@ def unified_attention_with_output(
         first_dim = output.shape[0]
         elems_per_token = output.numel() // first_dim
         output.view(first_dim, elems_per_token)[actual_tokens:].zero_()
+    return
+
+
+@register_custom_op(mutates_args=["attn_out", "idx_out"])
+@register_split_op()
+def unified_sparse_attention_with_output(
+    query: torch.Tensor,
+    key: Optional[torch.Tensor],
+    value: Optional[torch.Tensor],
+    attn_out: torch.Tensor,
+    idx_out: torch.Tensor,
+    idx_q: torch.Tensor,
+    idx_k: torch.Tensor,
+    save_kv_cache: bool,
+    layer_id: int,
+    *,
+    idx_v: Optional[torch.Tensor] = None,
+) -> None:
+    # MiniMax-M3 sparse attention: the lightning indexer + sparse main attn
+    # host-sync, so they run eagerly as the piecewise split boundary. Unlike the
+    # dense op this writes TWO preallocated buffers — the main attention output
+    # and the indexer output — so the surrounding o_proj / index_o_proj GEMMs
+    # stay captured.
+    context = get_tc_piecewise_forward_context()
+    forward_batch = context.forward_batch
+    attention_layer = context.attention_layers[layer_id]
+    real_num_tokens = forward_batch.num_token_non_padded_cpu
+
+    query = query[:real_num_tokens]
+    if key is not None:
+        key = key[:real_num_tokens]
+    if value is not None:
+        value = value[:real_num_tokens]
+    idx_q = idx_q[:real_num_tokens]
+    idx_k = idx_k[:real_num_tokens]
+    if idx_v is not None:
+        idx_v = idx_v[:real_num_tokens]
+
+    original_out_cache_loc = forward_batch.out_cache_loc
+    forward_batch.out_cache_loc = original_out_cache_loc[:real_num_tokens]
+
+    ret_idx, ret_out = get_attn_backend().forward(
+        query,
+        key,
+        value,
+        attention_layer,
+        forward_batch,
+        save_kv_cache,
+        idx_q=idx_q,
+        idx_k=idx_k,
+        idx_v=idx_v,
+    )
+    forward_batch.out_cache_loc = original_out_cache_loc
+
+    attn_out[:real_num_tokens].view(ret_out.shape).copy_(ret_out)
+    # disable_value layers return idx_out=None and never read idx_o (the model
+    # returns before index_o_proj), so leaving that buffer untouched is safe.
+    if ret_idx is not None:
+        idx_out[:real_num_tokens].view(ret_idx.shape).copy_(ret_idx)
+
+    # Zero padded positions so empty-buffer garbage (NaN/Inf) cannot propagate
+    # through residual / MoE routing / allreduce — mirrors the dense split op.
+    pcg_static_tokens = context.num_tokens
+    actual_tokens = context.raw_num_tokens
+    if (
+        pcg_static_tokens is not None
+        and actual_tokens is not None
+        and pcg_static_tokens > actual_tokens
+    ):
+        for buf in (attn_out, idx_out):
+            first_dim = buf.shape[0]
+            elems_per_token = buf.numel() // first_dim
+            buf.view(first_dim, elems_per_token)[actual_tokens:].zero_()
     return
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1485,7 +1485,7 @@ class ServerArgs:
             ),
             ("MoE A2A backend", lambda: self.moe_a2a_backend != "none"),
             ("LoRA", lambda: bool(self.lora_paths) or self.enable_lora),
-            ("multimodal model", lambda: self.get_model_config().is_multimodal),
+            # Multimodal is gated by the model-arch rule above (piecewise captures only the LM decoder prefill).
             (
                 "GGUF quantization",
                 lambda: self.load_format == "gguf"


### PR DESCRIPTION
## What

Enable **piecewise CUDA graph (tc_piecewise) prefill** for MiniMax-M3's sparse attention path, and turn it **on by default** for M3.

Two commits:
1. `piecewise CUDA graph for sparse prefill` — make the M3 sparse attention prefill capturable under tc_piecewise.
2. `enable piecewise CUDA graph by default` — exempt M3 from the multimodal auto-disable so PCG is the default (text **and** image).

## Why

`tc_piecewise` is already the global default prefill backend, but two things blocked it for M3:
- The sparse `self.attn(...)` returns a 2-tuple `(idx_o, attn_output)` with extra `idx_q/idx_k/idx_v` inputs, which doesn't match the single-output / returns-`None` `unified_attention_with_output` split op → dynamo breaks tracing through the lightning indexer + MSA.
- The fused Gemma-qknorm-RoPE tvm-ffi kernel is opaque to dynamo.
- M3 is a VL arch, so the `multimodal model` rule in `_disable_tc_piecewise_cudagraph_if_incompatible` disabled PCG entirely.

## How

- **radix_attention.py**: add a dual-output split op `unified_sparse_attention_with_output` (mutates `attn_out` + `idx_out`) for the sparse path; route sparse `self.attn` through it in the piecewise branch.
- **minimax_qknorm_rope.py**: wrap the fused qknorm-rope FFI launch as a `register_custom_op` so dynamo traces past it (launch is graph-capturable — host-side constant offsets).
- **Default-on gate**: piecewise only captures the **language-model decoder** prefill; the image encoder runs eager *outside* the captured region and image embeddings enter as a runtime graph input, so multimodal input is graph-safe. Add a per-arch allowlist `multimodal_piecewise_cuda_graph_supported_archs` (M3 only) and exempt it from the multimodal disable rule — **no behavior change for other multimodal models**.

Model code (`minimax_m3.py`) is untouched.

## Validation (B200, TP8, MXFP8)

**Correctness** — GSM8K full 1319 (sgl-eval, temp 0):
| mode | sglang (PCG) | vLLM latest (ref) |
|---|---|---|
| thinking | 0.9659 | 0.9719 |
| no-thinking | 0.9718 | 0.9712 |

Single-request greedy: clean `finish=stop` (`</mm:think> … \boxed{X}` + EOS), matching vLLM.

**Prefill latency** — same base, in1024/out512, PCG on vs off (eager prefill):
| conc | TTFT on | TTFT off | speedup | out tok/s on/off |
|---|---|---|---|---|
| 1 | 64 ms | 91 ms | 1.4× | 96.5 / 96.2 |
| 8 | 190 ms | 762 ms | **4.0×** | 621 / 573 |
| 64 | 791 ms | 922 ms | 1.16× | 2913 / 2829 |

TPOT unchanged (PCG is prefill-only).

**Multimodal** — image request under PCG returns clean (`finish=stop`, correctly describes the image), capture succeeds on all ranks.

**Default-on** — launched with no cuda-graph flags: `prefill backend = tc_piecewise`, piecewise capture on all 8 ranks, text + image both terminate cleanly.

## Notes

- Rebased onto the AR-fusion-revert head, so the default config is AR-fusion-off (the fusion is a separate, known M3 EOS-runaway issue tracked elsewhere).
