### PR TITLE
Fix MiniMax-M3 allreduce fusion correctness

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -840,7 +840,7 @@ class GemmaRMSNorm(MultiPlatformOp):
             residual,
             post_residual_addition,
             self.gemma_weight,
-            use_attn_tp_group=True,
+            use_attn_tp_group=use_attn_tp_group,
         )
 
 

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -1458,6 +1458,9 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 forward_batch
             )
         )
+        # Match vLLM's M3 path: only dense MLP output is deferred into the next norm.
+        if self.is_layer_sparse:
+            should_allreduce_fusion = False
         if (
             _is_hip
             and self.is_layer_sparse

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2845,7 +2845,7 @@ class ServerArgs:
 
         # TRTLLM AllReduce Fusion supports SM90/100, enable it by default
         # for models with explicit support (DeepseekV3, GptOss, Glm4Moe,
-        # MistralLarge3, Qwen3/Qwen3Next/Qwen3.5 MoE families)
+        # MiniMaxM3, MistralLarge3, Qwen3/Qwen3Next/Qwen3.5 MoE families)
         # TODO: currently, it is only supported in the single node scenario. https://github.com/flashinfer-ai/flashinfer/issues/2006
 
         if (
@@ -2864,6 +2864,8 @@ class ServerArgs:
                 "KimiK25ForConditionalGeneration",
                 "Qwen3_5MoeForConditionalGeneration",
                 "InternS2PreviewForConditionalGeneration",
+                "MiniMaxM3SparseForCausalLM",
+                "MiniMaxM3SparseForConditionalGeneration",
                 "Qwen3_5ForConditionalGeneration",
             ]
             and (is_sm90_supported() or is_sm100_supported())


### PR DESCRIPTION
## Summary

Enable FlashInfer TRTLLM allreduce fusion by default for MiniMax-M3 while preserving generation correctness.

Root cause:
- The FlashInfer AR kernel was not the correctness culprit. Layer-by-layer fused-vs-native checks showed the fused AR+Gemma RMSNorm op stayed finite and close to native on identical inputs.
- SGLang's MiniMax-M3 forward path was deferring sparse MoE output allreduce into the next layer norm through the generic `LayerCommunicator` path.
- vLLM's MiniMax-M3 forward path only defers dense MLP output into the next norm; sparse MoE layers immediately all-reduce. This patch matches that contract.

Changes:
- Forward `use_attn_tp_group` correctly from `GemmaRMSNorm.forward_with_allreduce_fusion`.
- For MiniMax-M3 sparse MoE layers, force immediate MLP/MoE allreduce instead of deferring into the next input norm. Dense MLP layers still keep the fused deferred path.
- Add `MiniMaxM3SparseForCausalLM` and `MiniMaxM3SparseForConditionalGeneration` to the FlashInfer allreduce-fusion auto-enable allowlist.

## Correctness

H200 TP8, MiniMax-M3, FlashInfer AR fusion ON.

GSM8K stop-rate validation, no CUDA graph:
- Artifact: `/scratch/ar-dense-only-val/smoke100.jsonl.summary.json`
- `n_total=100`, `n_ok=100`, `n_err=0`
- `stop_rate_pct=100.0`
- `runaway_rate_pct=0.0`
- `ct_p50=223`, `ct_p99=599`, `ct_max=650`
- `gsm8k_acc_pct=96.0`

GSM8K stop-rate validation, CUDA graph enabled:
- Artifact: `/scratch/ar-dense-only-graph-val/smoke100.jsonl.summary.json`
- `n_total=100`, `n_ok=100`, `n_err=0`
- `stop_rate_pct=100.0`
- `runaway_rate_pct=0.0`
- `ct_p50=226`, `ct_p99=656`, `ct_max=756`
- `gsm8k_acc_pct=95.0`

The validation criterion here is `finish_reason=stop` / stop-rate, not GSM8K accuracy alone.

## Performance

H200 TP8, CUDA graph enabled, SGLang `bench_serving`, random workload:
- `--random-input-len 1024`
- `--random-output-len 512`
- `--num-prompts 128`
- `--max-concurrency 32`

Fusion ON artifact:
- `/scratch/ar-fusion-perf/fusion_on/bench.jsonl`
- Log confirms default enable: `Auto-enabling FlashInfer AllReduce Fusion on SM90/SM10X for MiniMaxM3SparseForConditionalGeneration`

Native baseline artifact:
- `/scratch/ar-fusion-perf/native_baseline/bench.jsonl`
- Launched with `--enforce-disable-flashinfer-allreduce-fusion`

| Arm | Output throughput | Mean TPOT | Median TPOT | P99 TPOT | Median TTFT |
| --- | ---: | ---: | ---: | ---: | ---: |
| Fusion ON | 1011.78 tok/s | 29.37 ms | 29.69 ms | 39.55 ms | 146.19 ms |
| Native baseline | 1023.78 tok/s | 29.07 ms | 29.45 ms | 39.68 ms | 147.25 ms |

Delta, fusion ON vs native:
- Output throughput: `-12.00 tok/s` (`-1.17%`)
- Mean TPOT: `+0.30 ms` (`+1.02%`)
- Median TPOT: `+0.23 ms` (`+0.79%`)

This is neutral/slightly negative on H200, where MiniMax-M3 is still on the Triton MoE fallback. The larger AR-fusion gain is expected on B200/MSA and is intentionally left as follow-up.

## Checks

- `python3 -m py_compile python/sglang/srt/layers/layernorm.py python/sglang/srt/models/minimax_m3.py python/sglang/srt/server_args.py`
- `pre-commit run --files python/sglang/srt/layers/layernorm.py python/sglang/srt/models/minimax_m3.py python/sglang/srt/server_args.py`

## Follow-up

- B200/MSA correctness and performance validation.
