### PR TITLE
[minimax-m3] Allow Triton MoE runner for mxfp8 on AMD gfx950

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -45,6 +45,7 @@ from sglang.srt.utils.common import (
     is_cpu,
     is_cuda,
     is_flashinfer_available,
+    is_gfx95_supported,
     is_hip,
     is_musa,
     is_npu,
@@ -1818,20 +1819,29 @@ def _moe_runner_backend_quant_constraints(view: Any) -> dict:
                 "flashinfer_trtllm_routed."
             )
     if view.quantization == "mxfp8":
-        if moe_runner_backend == "auto":
-            moe_runner_backend = "flashinfer_trtllm"
-        elif moe_runner_backend not in [
+        # AMD CDNA4 (gfx950) has a native mxfp8 Triton MoE runner
+        # (moe_runner/triton.py -> fused_experts_mxfp8, guarded by
+        # is_hip() and is_gfx95_supported()); the flashinfer_trtllm path is
+        # CUDA-only. Prefer/keep Triton there instead of forcing flashinfer.
+        gfx95_mxfp8 = is_hip() and is_gfx95_supported()
+        allowed = [
             "cutlass",
             "deep_gemm",
             "flashinfer_trtllm",
             "flashinfer_trtllm_routed",
-        ]:
+        ]
+        if gfx95_mxfp8:
+            allowed.append("triton")
+        if moe_runner_backend == "auto":
+            moe_runner_backend = "triton" if gfx95_mxfp8 else "flashinfer_trtllm"
+        elif moe_runner_backend not in allowed:
             logger.warning(
-                "mxfp8 quantization supports only cutlass, deep_gemm, "
-                "flashinfer_trtllm, or flashinfer_trtllm_routed backends. "
-                f"Overriding {moe_runner_backend!r}."
+                "mxfp8 quantization supports only %s backends. "
+                "Overriding %r.",
+                ", ".join(allowed),
+                moe_runner_backend,
             )
-            moe_runner_backend = "flashinfer_trtllm"
+            moe_runner_backend = "triton" if gfx95_mxfp8 else "flashinfer_trtllm"
     if (
         moe_runner_backend == "auto"
         and view.quantization == "modelopt_fp4"


### PR DESCRIPTION
## Problem

Launching `MiniMaxAI/MiniMax-M3-MXFP8` with `--quantization mxfp8` on AMD MI355X (CDNA4 / gfx950) crashes during weight post-processing:

```
align_mxfp8_moe_weights_for_flashinfer_trtllm(layer)
  from flashinfer import block_scale_interleave
ModuleNotFoundError: No module named 'flashinfer'
```

`_moe_runner_backend_quant_constraints` (arg_groups/overrides.py) forces `moe_runner_backend` to `flashinfer_trtllm` for mxfp8 whenever the requested backend isn't one of `{cutlass, deep_gemm, flashinfer_trtllm, flashinfer_trtllm_routed}` — including the `triton` backend and `auto`. On gfx950 flashinfer is unavailable, so this override guarantees a load-time crash.

This is inconsistent with the runtime, which already has a native mxfp8 MoE path for gfx950: `moe_runner/triton.py` dispatches to `fused_experts_mxfp8` under `is_hip() and is_gfx95_supported()` (with a tuned `minimax_m3_gfx950_mxfp8_compact_moe.json`). The arg-override whitelist just never included Triton for that case (upstream recently added `deep_gemm` to the same list).

## Fix

Whitelist `triton` for mxfp8 when `is_hip() and is_gfx95_supported()`, and resolve `auto` to `triton` on gfx950 (flashinfer_trtllm can never load there). Non-gfx950 behavior is unchanged.

## Testing

On MI355X (gfx950), TP4, `--quantization mxfp8 --moe-runner-backend triton --attention-backend aiter`: server now loads and serves correctly. A full concurrency sweep (1→512) at ISL=OSL=1024 produced valid, monotonic throughput (up to ~5018 output tok/s @ conc=512) with sane TTFT/TPOT — confirming the gfx950 mxfp8 Triton path works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)