### PR TITLE
[Qwen3.5] Fuse GDN decode split and causal conv

### DIFF
--- a/python/sglang/kernels/ops/attention/triton_gdn_fused_proj.py
+++ b/python/sglang/kernels/ops/attention/triton_gdn_fused_proj.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import torch
 import triton
 import triton.language as tl
+
+
+class GDNDecodeProjection(NamedTuple):
+    projected_qkvz: torch.Tensor
+    projected_ba: torch.Tensor
+    mixed_qkv: torch.Tensor
+    z: torch.Tensor
+
 
 # =============================================================================
 # Fused kernel — reads INTERLEAVED input format
@@ -308,6 +318,142 @@ def fused_qkvzba_split_reshape_cat_contiguous(
         num_stages=3,
     )
     return mixed_qkv, z, b, a
+
+
+@triton.jit
+def fused_qkvz_split_conv1d_update_contiguous_kernel(
+    projected_qkvz,
+    projected_ba,
+    mixed_qkv,
+    z,
+    b,
+    a,
+    conv_state,
+    weight,
+    cache_indices,
+    stride_projected_token: tl.constexpr,
+    stride_projected_ba_token: tl.constexpr,
+    stride_mixed_token: tl.constexpr,
+    stride_z_token: tl.constexpr,
+    stride_b_token: tl.constexpr,
+    stride_a_token: tl.constexpr,
+    stride_state_sequence: tl.constexpr,
+    stride_state_feature: tl.constexpr,
+    stride_state_token: tl.constexpr,
+    stride_weight_feature: tl.constexpr,
+    stride_weight_width: tl.constexpr,
+    stride_cache_indices: tl.constexpr,
+    QKV_DIM: tl.constexpr,
+    Z_DIM: tl.constexpr,
+    PAD_SLOT_ID: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    feature_offsets = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    qkv_mask = feature_offsets < QKV_DIM
+    projected_base = projected_qkvz + token_idx * stride_projected_token
+    values = tl.load(projected_base + feature_offsets, mask=qkv_mask)
+
+    z_mask = feature_offsets < Z_DIM
+    z_values = tl.load(
+        projected_base + QKV_DIM + feature_offsets,
+        mask=z_mask,
+    )
+    tl.store(z + token_idx * stride_z_token + feature_offsets, z_values, mask=z_mask)
+
+    if tl.program_id(1) == 0:
+        ba_offsets = tl.arange(0, 16)
+        projected_ba_base = projected_ba + token_idx * stride_projected_ba_token
+        tl.store(
+            b + token_idx * stride_b_token + ba_offsets,
+            tl.load(projected_ba_base + ba_offsets),
+        )
+        tl.store(
+            a + token_idx * stride_a_token + ba_offsets,
+            tl.load(projected_ba_base + 16 + ba_offsets),
+        )
+
+    state_idx = tl.load(cache_indices + token_idx * stride_cache_indices)
+    if state_idx == PAD_SLOT_ID:
+        return
+
+    state_base = (
+        conv_state
+        + state_idx * stride_state_sequence
+        + feature_offsets * stride_state_feature
+    )
+    state_0 = tl.load(state_base, mask=qkv_mask)
+    state_1 = tl.load(state_base + stride_state_token, mask=qkv_mask)
+    state_2 = tl.load(state_base + 2 * stride_state_token, mask=qkv_mask)
+
+    weight_base = weight + feature_offsets * stride_weight_feature
+    weight_0 = tl.load(weight_base, mask=qkv_mask)
+    weight_1 = tl.load(weight_base + stride_weight_width, mask=qkv_mask)
+    weight_2 = tl.load(weight_base + 2 * stride_weight_width, mask=qkv_mask)
+    weight_3 = tl.load(weight_base + 3 * stride_weight_width, mask=qkv_mask)
+
+    tl.debug_barrier()
+    tl.store(state_base, state_1, mask=qkv_mask)
+    tl.store(state_base + stride_state_token, state_2, mask=qkv_mask)
+    tl.store(state_base + 2 * stride_state_token, values, mask=qkv_mask)
+
+    output = tl.zeros((BLOCK_N,), dtype=tl.float32)
+    output += state_0 * weight_0
+    output += state_1 * weight_1
+    output += state_2 * weight_2
+    output += values * weight_3
+    output = output / (1 + tl.exp(-output))
+    tl.store(
+        mixed_qkv + token_idx * stride_mixed_token + feature_offsets,
+        output,
+        mask=qkv_mask,
+    )
+
+
+def fused_qkvz_split_conv1d_update_contiguous(
+    projected_qkvz: torch.Tensor,
+    projected_ba: torch.Tensor,
+    mixed_qkv: torch.Tensor,
+    z: torch.Tensor,
+    b: torch.Tensor,
+    a: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    cache_indices: torch.Tensor,
+    pad_slot_id: int,
+) -> None:
+    qkv_dim = mixed_qkv.shape[1]
+    z_dim = z.shape[1] * z.shape[2]
+    grid = (projected_qkvz.shape[0], triton.cdiv(qkv_dim, 256))
+    fused_qkvz_split_conv1d_update_contiguous_kernel[grid](
+        projected_qkvz,
+        projected_ba,
+        mixed_qkv,
+        z,
+        b,
+        a,
+        conv_state,
+        weight,
+        cache_indices,
+        projected_qkvz.stride(0),
+        projected_ba.stride(0),
+        mixed_qkv.stride(0),
+        z.stride(0),
+        b.stride(0),
+        a.stride(0),
+        conv_state.stride(0),
+        conv_state.stride(1),
+        conv_state.stride(2),
+        weight.stride(0),
+        weight.stride(1),
+        cache_indices.stride(0),
+        qkv_dim,
+        z_dim,
+        pad_slot_id,
+        BLOCK_N=256,
+        num_warps=1,
+        num_stages=3,
+    )
 
 
 @triton.jit

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -32,6 +32,11 @@ if is_cuda() or is_hip():
         fused_qkv_split_gdn_prefill,
     )
 
+if is_cuda():
+    from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+        fused_qkvz_split_conv1d_update_contiguous,
+    )
+
 MAX_FUSED_QKV_SPLIT_DIM = 8192
 
 if is_cuda():
@@ -389,15 +394,30 @@ class GDNAttnBackend(MambaAttnBackendBase):
         replayssm_k = layer_cache.replayssm_k
         replayssm_g = layer_cache.replayssm_g
 
-        assert isinstance(mixed_qkv, torch.Tensor)
-        mixed_qkv = causal_conv1d_update(
-            mixed_qkv,
-            conv_states,
-            layer.conv_weights,
-            layer.bias,
-            layer.activation,
-            conv_state_indices=cache_indices,
-        )
+        if isinstance(mixed_qkv, tuple):
+            projected_qkvz, projected_ba, mixed_qkv, z = mixed_qkv
+            fused_qkvz_split_conv1d_update_contiguous(
+                projected_qkvz,
+                projected_ba,
+                mixed_qkv,
+                z,
+                b,
+                a,
+                conv_states,
+                layer.conv_weights,
+                cache_indices,
+                self.pad_slot_id,
+            )
+        else:
+            assert isinstance(mixed_qkv, torch.Tensor)
+            mixed_qkv = causal_conv1d_update(
+                mixed_qkv,
+                conv_states,
+                layer.conv_weights,
+                layer.bias,
+                layer.activation,
+                conv_state_indices=cache_indices,
+            )
 
         # Skip split + reshape + separate gating kernel by consuming
         # the packed mixed_qkv directly in a single fused Triton kernel.

--- a/python/sglang/srt/layers/radix_linear_attention.py
+++ b/python/sglang/srt/layers/radix_linear_attention.py
@@ -78,7 +78,7 @@ class RadixLinearAttention(nn.Module):
     def forward(
         self,
         forward_batch: ForwardBatch,
-        mixed_qkv: torch.Tensor,
+        mixed_qkv: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
         a: torch.Tensor,
         b: torch.Tensor,
     ) -> torch.Tensor:

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -28,6 +28,7 @@ from sglang.kernels.ops.attention.fla.layernorm_gated import (
     rms_norm_gated_fp8_quant,
 )
 from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+    GDNDecodeProjection,
     fused_qkvzba_split_reshape_cat_contiguous,
 )
 from sglang.kernels.ops.elementwise.elementwise import fused_sigmoid_mul
@@ -45,6 +46,7 @@ from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.layers.attention.linear.utils import get_linear_attn_decode_backend
 from sglang.srt.layers.attention.mamba.mamba import mamba_v2_sharded_weight_loader
 from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
 from sglang.srt.layers.dp_attention import (
@@ -650,6 +652,32 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             projected_states_ba, _ = self.in_proj_ba(hs_bf16)
         return projected_states_qkvz, projected_states_ba
 
+    def _can_fuse_decode_split_conv(
+        self,
+        projected_states_qkvz: torch.Tensor,
+        projected_states_ba: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> bool:
+        server_args = get_server_args()
+        return (
+            _is_cuda
+            and forward_batch.forward_mode.is_decode()
+            and forward_batch.spec_info is None
+            and get_linear_attn_decode_backend().is_triton()
+            and not server_args.enable_linear_replayssm
+            and not server_args.enable_gdn_replayssm_spec
+            and self.conv_kernel_size == 4
+            and self.attn.bias is None
+            and self.activation in ("silu", "swish")
+            and projected_states_qkvz.is_contiguous()
+            and projected_states_ba.is_contiguous()
+            and projected_states_qkvz.shape[1] == 6144
+            and projected_states_ba.shape[1] == 32
+            and self.attn.q_dim == 1024
+            and self.attn.k_dim == 1024
+            and self.attn.v_dim == 2048
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -665,7 +693,26 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             hidden_states
         )
 
-        if self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_npu:
+        if self._can_fuse_decode_split_conv(
+            projected_states_qkvz,
+            projected_states_ba,
+            forward_batch,
+        ):
+            mixed_qkv_output = projected_states_qkvz.new_empty(
+                projected_states_qkvz.shape[0], 4096
+            )
+            z = projected_states_qkvz.new_empty(
+                projected_states_qkvz.shape[0], 16, self.head_v_dim
+            )
+            b = projected_states_ba.new_empty(projected_states_ba.shape[0], 16)
+            a = torch.empty_like(b)
+            mixed_qkv = GDNDecodeProjection(
+                projected_states_qkvz,
+                projected_states_ba,
+                mixed_qkv_output,
+                z,
+            )
+        elif self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_npu:
             if _is_cpu:
                 num_k_heads_tp = self.num_k_heads // self.attn_tp_size
                 num_v_heads_tp = self.num_v_heads // self.attn_tp_size

--- a/test/registered/attention/test_gdn_qkvz_split_conv.py
+++ b/test/registered/attention/test_gdn_qkvz_split_conv.py
@@ -1,0 +1,193 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+    fused_qkvz_split_conv1d_update_contiguous,
+    fused_qkvzba_split_reshape_cat_contiguous,
+)
+from sglang.kernels.ops.mamba.causal_conv1d_triton import (
+    PAD_SLOT_ID,
+    causal_conv1d_update,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
+
+QK_HEADS = 8
+V_HEADS = 16
+HEAD_DIM = 128
+QKV_DIM = 4096
+Z_DIM = 2048
+BA_DIM = 32
+
+
+def _make_inputs(batch: int, seed: int):
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    projected_qkvz = torch.randn(
+        batch,
+        QKV_DIM + Z_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    projected_ba = torch.randn(
+        batch,
+        BA_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    weight = torch.randn(
+        QKV_DIM,
+        4,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    storage = torch.randn(
+        batch + 9,
+        3,
+        QKV_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    state = storage.transpose(1, 2)
+    cache_indices = torch.randperm(
+        batch + 9,
+        dtype=torch.int32,
+        device="cuda",
+        generator=generator,
+    )[:batch]
+    if batch > 1:
+        cache_indices[-1] = PAD_SLOT_ID
+    return projected_qkvz, projected_ba, weight, state, cache_indices
+
+
+def _reference(projected_qkvz, projected_ba, weight, state, cache_indices):
+    mixed_qkv, z, b, a = fused_qkvzba_split_reshape_cat_contiguous(
+        projected_qkvz,
+        projected_ba,
+        QK_HEADS,
+        V_HEADS,
+        HEAD_DIM,
+        HEAD_DIM,
+    )
+    mixed_qkv = causal_conv1d_update(
+        mixed_qkv,
+        state,
+        weight,
+        activation="silu",
+        conv_state_indices=cache_indices,
+    )
+    return mixed_qkv, z, b, a
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("batch", [1, 32])
+def test_matches_split_then_conv(batch):
+    projected_qkvz, projected_ba, weight, state, cache_indices = _make_inputs(
+        batch, seed=batch
+    )
+    reference_state = state.clone(memory_format=torch.preserve_format)
+    mixed_ref, z_ref, b_ref, a_ref = _reference(
+        projected_qkvz,
+        projected_ba,
+        weight,
+        reference_state,
+        cache_indices,
+    )
+
+    mixed = torch.empty_like(mixed_ref)
+    z = torch.empty_like(z_ref)
+    b = torch.empty_like(b_ref)
+    a = torch.empty_like(a_ref)
+    fused_qkvz_split_conv1d_update_contiguous(
+        projected_qkvz,
+        projected_ba,
+        mixed,
+        z,
+        b,
+        a,
+        state,
+        weight,
+        cache_indices,
+        PAD_SLOT_ID,
+    )
+
+    valid = cache_indices != PAD_SLOT_ID
+    torch.testing.assert_close(mixed[valid], mixed_ref[valid], atol=0, rtol=0)
+    torch.testing.assert_close(z, z_ref, atol=0, rtol=0)
+    torch.testing.assert_close(b, b_ref, atol=0, rtol=0)
+    torch.testing.assert_close(a, a_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state, reference_state, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_cuda_graph_replay():
+    batch = 32
+    projected_qkvz, projected_ba, weight, state, cache_indices = _make_inputs(
+        batch, seed=101
+    )
+    initial_state = state.clone(memory_format=torch.preserve_format)
+    mixed = torch.empty(batch, QKV_DIM, dtype=torch.bfloat16, device="cuda")
+    z = torch.empty(batch, V_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    b = torch.empty(batch, V_HEADS, dtype=torch.bfloat16, device="cuda")
+    a = torch.empty_like(b)
+
+    fused_qkvz_split_conv1d_update_contiguous(
+        projected_qkvz,
+        projected_ba,
+        mixed,
+        z,
+        b,
+        a,
+        state,
+        weight,
+        cache_indices,
+        PAD_SLOT_ID,
+    )
+    state.copy_(initial_state)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fused_qkvz_split_conv1d_update_contiguous(
+            projected_qkvz,
+            projected_ba,
+            mixed,
+            z,
+            b,
+            a,
+            state,
+            weight,
+            cache_indices,
+            PAD_SLOT_ID,
+        )
+
+    new_qkvz, new_ba, new_weight, new_state, _ = _make_inputs(batch, seed=202)
+    projected_qkvz.copy_(new_qkvz)
+    projected_ba.copy_(new_ba)
+    weight.copy_(new_weight)
+    state.copy_(new_state)
+    reference_state = new_state.clone(memory_format=torch.preserve_format)
+    mixed_ref, z_ref, b_ref, a_ref = _reference(
+        projected_qkvz,
+        projected_ba,
+        weight,
+        reference_state,
+        cache_indices,
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    valid = cache_indices != PAD_SLOT_ID
+    torch.testing.assert_close(mixed[valid], mixed_ref[valid], atol=0, rtol=0)
+    torch.testing.assert_close(z, z_ref, atol=0, rtol=0)
+    torch.testing.assert_close(b, b_ref, atol=0, rtol=0)
+    torch.testing.assert_close(a, a_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state, reference_state, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

- Fuse the contiguous QKVZ/BA split with the width-4 causal-conv update for the guarded Qwen3.5 normal CUDA Triton decode path.
- Keep the packed recurrent kernel and all unsupported decode, speculative, ReplaySSM, and alternate-backend paths unchanged.
- Add focused B200 coverage for batch 1/32, non-monotonic cache indices, the padding slot, untouched cache rows, and CUDA graph replay.

This PR is stacked on sgl-project/sglang#32443. The performance comparison below uses its head commit `ba466b8bf6` as the control.

## Performance

Model: `Qwen/Qwen3.6-35B-A3B-FP8` at revision `95a723d0`, 2× B200, TP2.

The retained decode profiles contain 150 affected launches per rank:

| Rank | Split + conv control | Fused | Reduction |
| --- | ---: | ---: | ---: |
| TP0 | 866.458 µs | 478.560–484.158 µs | 44.1–44.8% |
| TP1 | 871.936 µs | 481.062–483.953 µs | 44.5–44.8% |

The serving benchmark used 80 random-ID requests at QPS 4, exact 1,000-token outputs, `--flush-cache` before every run, and paired seeds 42/43/44:

| Workload | Control median | Candidate median | Delta |
| --- | ---: | ---: | ---: |
| `1000→1000` | 3.405943 req/s | 3.421262 req/s | +0.45% |
| `8000→1000` | 3.137935 req/s | 3.161666 req/s | +0.76% |

The two-workload geomean improves 0.60%. All six paired runs improve, and the median TTFT, TPOT, ITL, and E2E latency improve in both workloads.

Server configuration:

```bash
python -m sglang.launch_server \
  --model-path Qwen/Qwen3.6-35B-A3B-FP8 \
  --revision 95a723d08a9490559dae23d0cff1d9466213d989 \
  --tp-size 2 --context-length 65536 --quantization fp8 \
  --mem-fraction-static 0.80 --attention-backend trtllm_mha \
  --linear-attn-prefill-backend triton \
  --linear-attn-decode-backend triton \
  --chunked-prefill-size 8192 --max-running-requests 32
```

## Validation

- `pre-commit run --files <changed files>`
- `python -m pytest -q test/registered/attention/test_gdn_qkvz_split_conv.py` — 3 passed
- Full GSM8K, 1,319 examples × 2 repeats:
  - candidate/control accuracy: 95.75% / 95.41%
  - candidate/control stop-rate: 96.93% / 96.06%
  - 2,638/2,638 predictions and zero errors for both
